### PR TITLE
Correct relative project path argument

### DIFF
--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -38,6 +38,12 @@ namespace Depends
         {
             if (File.Exists(Project))
             {
+                // Correct relative paths so they work when passed to Uri
+                if (Path.GetFullPath(Project) != Project && File.Exists(Path.GetFullPath(Project)))
+                {
+                    Project = Path.GetFullPath(Project);
+                }
+
                 return ValidationResult.Success;
             }
 


### PR DESCRIPTION
A relative project path can be successfully validated, but fails in Buildalyzer.Analyze because it's expecting a full path when building a URI. The fix checks whether the resolved path differs from what's passed and, if it exists, replaces the relative with an absolute.