### PR TITLE
Define Color Scheme

### DIFF
--- a/src/Depends/Depends.csproj
+++ b/src/Depends/Depends.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.4.2" />
-    <PackageReference Include="Terminal.Gui" Version="0.24.0" />
+    <PackageReference Include="Terminal.Gui" Version="0.81.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -224,10 +224,10 @@ namespace Depends
             {
                 ColorScheme = new ColorScheme
                 {
-                    Focus = Application.Driver.MakeAttribute(Color.White, Color.Black),
-                    Normal = Application.Driver.MakeAttribute(Color.Black, Color.White),
-                    HotFocus = Application.Driver.MakeAttribute(Color.White, Color.Black),
-                    HotNormal = Application.Driver.MakeAttribute(Color.Blue, Color.White)
+                    Focus = Application.Driver.MakeAttribute(Color.Black, Color.White),
+                    Normal = Application.Driver.MakeAttribute(Color.White, Color.Black),
+                    HotFocus = Application.Driver.MakeAttribute(Color.Black, Color.White),
+                    HotNormal = Application.Driver.MakeAttribute(Color.Black, Color.White)
                 };
             }
 

--- a/src/Depends/Program.cs
+++ b/src/Depends/Program.cs
@@ -220,7 +220,16 @@ namespace Depends
 
         private class CustomWindow : Window
         {
-            public CustomWindow() : base("Depends", 0) { }
+            public CustomWindow() : base("Depends", 0)
+            {
+                ColorScheme = new ColorScheme
+                {
+                    Focus = Application.Driver.MakeAttribute(Color.White, Color.Black),
+                    Normal = Application.Driver.MakeAttribute(Color.Black, Color.White),
+                    HotFocus = Application.Driver.MakeAttribute(Color.White, Color.Black),
+                    HotNormal = Application.Driver.MakeAttribute(Color.Blue, Color.White)
+                };
+            }
 
             public ListView DependenciesView { get; set; }
             public ImmutableList<Node> Dependencies { get; set; }


### PR DESCRIPTION
This should make for a consistent experience
across terminals. This defines a basic black/white
color scheme.

 #Hacktoberfest

Each terminal defines its concepts of **Black** and **White**.

## In iTerm2

![image](https://user-images.githubusercontent.com/228256/94191652-d408cb00-fe7b-11ea-9eae-2e95b5c198a8.png)

## Inside JetBrains Rider (Dark Theme)

<img width="1280" alt="Screenshot 2020-09-24 at 15 33 21@2x" src="https://user-images.githubusercontent.com/228256/94191538-a3289600-fe7b-11ea-8161-63d6a6f3e70d.png">
